### PR TITLE
(deprrcated): [DO NOT MERGE] Adding openebs reinstallation test case 

### DIFF
--- a/litmus/director/dop-openebs-reinstallation/run_litmus_test.yml
+++ b/litmus/director/dop-openebs-reinstallation/run_litmus_test.yml
@@ -1,0 +1,94 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: dop-openebs-reinstallation-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: openebs-install-check-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+          
+          ## Take url from configmap config
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Take cluster_id from configmap clusterid
+          - name: CLUSTER_ID    
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          ## Takes group_id from configmap groupid
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          ## It should be 1ot1 Mandatory
+          - name: TEMPLATE_ID
+            value: '1ot1'
+
+          ## Namespace where openebs is installed
+          ## By default in basic mode it is openebs
+          - name: NAMESPACE
+            value: ''
+
+          ## Enter the default directory - It can be /var/openebs
+          - name: DEFAULT_DIRECTORY
+            value: ''
+
+          ##Enter docker registry
+          - name: DOCKER_REGISTRY
+            value: ''
+
+          ## Enter include device filter
+          - name: INCLUDE_DEVICE_FILTERS
+            value: ''
+
+          ## Enter exclude device filter  
+          - name: EXCLUDE_DEVICE_FILTER
+            value: ''
+
+          ## Enter CPU resource limit
+          - name: CPU_RESOURCE_LIMIT
+            value: ''
+
+          ## Enter Memory resource limit
+          - name: MEMORY_RESOURCE_LIMIT
+            value: ''
+          
+          ## It will have values basic/advance
+          ## Note: For basic installation only template value slould be provided
+          ## For adding any additional value - change the installation mode to advance
+          - name: INSTALLATION_MODE
+            value: 'basic'
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: 'default'  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/dop-openebs-reinstallation/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/litmus/director/dop-openebs-reinstallation/test.yml
+++ b/litmus/director/dop-openebs-reinstallation/test.yml
@@ -1,0 +1,133 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+  
+    ## Generating the testname for deployment
+    - include_tasks: /ansible-utils/create_testname.yml
+
+    ## RECORD START-OF-TEST IN LITMUS RESULT CR
+    - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+      vars:
+        status: 'SOT'
+      
+    - set_fact:
+        director_url : "http://{{ director_ip }}:30380"
+    
+    ## Getting username
+    - name: Get username
+      shell: cat /etc/secret-volume/username
+      register: username
+
+    ## Getting password     
+    - name: Get password
+      shell: cat /etc/secret-volume/password
+      register: password
+
+    ## Getting into the cluster
+    - name: Check if the cluster is up and running
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/cluster/{{ cluster_id }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        status_code: 200
+      register: get_openebs
+
+    # Checking if openebs is already installed
+    - name: Checking the installation of OpenEBS
+      shell: kubectl get deploy maya-apiserver --all-namespaces --no-headers | wc -l
+      args:
+        executable: /bin/bash
+      register: maya_api
+
+    ## Install openebs if it is not already installed
+    - name: Install openebs if it is not already installed
+      shell: kubectl apply -f https://openebs.github.io/charts/openebs-operator-{{ openebs_version }}.yaml -n {{ namespace }}
+      args:
+        executable: /bin/bash
+      when: "{{ maya_api.stdout }} == 0"
+
+    ## Getting node details of the cluster
+    ## Selecting the node which is in active state in the cluster
+    - name: Getting the node details of the cluster which is in active state
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes?state=active&clusterId={{ cluster_id }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 200
+      register: node_cluster
+
+    ## Define variable node_id
+    - set_fact:
+        node_id: []
+
+    ## Storing the id of the nodes in the cluster
+    - name: Storing the id of nodes in the cluster
+      set_fact:
+        node_id: "{{ node_id  + [item.id] }}"
+      loop: "{{ node_cluster.json.data }}"
+
+    - block:
+
+        ## Labeling node-1 of the Cluster with controlPlaneNode=true and dataPlaneNode=false
+        ## With the first element in the node_id list
+        - name: Labeling node-1 of the cluster
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[0] }}/?action=labelnodes"
+            method: POST
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            status_code: 202
+            body_format: json
+            body: '{"controlPlaneNode": true, "dataPlaneNode": false }'
+          register: labelnode1
+
+        ## Labeling node-2 of the Cluster with controlPlaneNode=false and dataPlaneNode=true
+        ## With the second element in the node_id list
+        - name: Labeling node-2 of the cluster
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[1] }}/?action=labelnodes"
+            method: POST
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 202
+            body: '{"controlPlaneNode": false, "dataPlaneNode": true }'
+          register: labelnode2
+
+      when: "{{ node_id | length }} < 2"
+
+    ## Creating openebs
+    - name: Giving required variables for openebs installation
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/openebses"
+        method: POST
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        body: "{ \"clusterId\": \"{{ cluster_id }}\",\"creatorId\": \"{{ group_id }}\",\"projectId\": \"{{ project_id }}\",\"templateId\": \"{{ template_id }}\",\"namespace\": \"{{ namespace }}\",\"defaultDirectory\": \"{{ default_directory }}\",\"dockerRegistry\": \"{{ docker_registry }}\",\"includeDeviceFilters\": \"{{ include_device_filters }}\",\"excludeDeviceFilters\": \"{{ exclude_device_filters }}\",\"cpuResourceLimit\": \"{{ cpu_resource_limit }}\",\"memoryResourceLimit\": \" {{ memory_resource_limit }}\",\"installationMode\": \"{{ installation_mode }}\" }"            
+        status_code: 405
+      register: get_openebs
+
+    ## Giving warning
+    - name: Warning
+      debug:
+        msg: OpenEBS is Already  installed in your cluster. If you still want to install then please remove the older one and try again.     
+      when: "{{ create_openebs.json.status }} == 405"    

--- a/litmus/director/dop-openebs-reinstallation/test_vars.yml
+++ b/litmus/director/dop-openebs-reinstallation/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: dop-openebs-reinstallation
+openebs_components: ['openebs-provisioner','openebs-ndm-operator','openebs-ndm','openebs-snapshot-operator','openebs-admission-server','openebs-localpv-provisioner','maya-apiserver']
+group_id: "{{ lookup('env','GROUP_ID') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+template_id: "{{ lookup('env','TEMPLATE_ID') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"
+default_directory: "{{ lookup('env','DEFAULT_DIRECTORY') }}"
+docker_registry: "{{ lookup('env','DOCKER_REGISTRY') }}"
+include_device_filters: "{{ lookup('env','INCLUDE_DEVICE_FILTERS') }}"
+exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
+cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
+memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
+installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"
+openebs_version: "1.7.0"


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>
issue - https://github.com/mayadata-io/oep/issues/207
**_This PR is for:_**
- The openebs reinstallation test case 

**_Details:_**

- In openebs reinstallation test case we are installing openebs in a cluster where openebs is already installed. 

- For this firstly we have to check if the cluster contains openebs -- if not then we have to deploy openebs in the cluster  (in this case using operator YAML). After getting sure that openebs is present in the cluster we will try to reinstall the openebs in the cluster. 

- This will give the error `405` which will say `Openebs is already installed` . So for such situation we have to give proper `warning` to the user saying - Openebs is Already installed in your cluster. If you still want to install then please remove the older one and try again.  

**_Output of job logs:_**
- [x] [openebs-reinstallation.txt](https://github.com/mayadata-io/oep/files/4209261/openebs-reinstallation.txt)
