### PR TITLE
[deprecated]: [DO NOT MERGE] Adding test case for installing openebs control plane components on specific nodes

### DIFF
--- a/litmus/director/openebs-control-plane-test/run_litmus_test.yml
+++ b/litmus/director/openebs-control-plane-test/run_litmus_test.yml
@@ -1,0 +1,94 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openebs-control-plane-test-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: openebs-control-plane-test-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+          
+          ## Take url from configmap config
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Take cluster_id from configmap clusterid
+          - name: CLUSTER_ID    
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          ## Takes group_id from configmap groupid
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          ## It should be 1ot1 Mandatory
+          - name: TEMPLATE_ID
+            value: '1ot1'
+
+          ## Namespace where openebs is installed
+          ## By default in basic mode it is openebs
+          - name: NAMESPACE
+            value: ''
+
+          ## Enter the default directory - It can be /var/openebs
+          - name: DEFAULT_DIRECTORY
+            value: ''
+
+          ##Enter docker registry
+          - name: DOCKER_REGISTRY
+            value: ''
+
+          ## Enter include device filter
+          - name: INCLUDE_DEVICE_FILTERS
+            value: ''
+
+          ## Enter exclude device filter  
+          - name: EXCLUDE_DEVICE_FILTER
+            value: ''
+
+          ## Enter CPU resource limit
+          - name: CPU_RESOURCE_LIMIT
+            value: ''
+
+          ## Enter Memory resource limit
+          - name: MEMORY_RESOURCE_LIMIT
+            value: ''
+          
+          ## It will have values basic/advance
+          ## Note: For basic installation only template value slould be provided
+          ## For adding any additional value - change the installation mode to advance
+          - name: INSTALLATION_MODE
+            value: 'basic'
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: 'default'  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/openebs-control-plane-test/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/litmus/director/openebs-control-plane-test/test.yml
+++ b/litmus/director/openebs-control-plane-test/test.yml
@@ -1,0 +1,264 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+  
+    ## Generating the testname for deployment
+    - include_tasks: /ansible-utils/create_testname.yml
+
+    ## Record Start-Of-Test In Litmus Result CR
+    - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+      vars:
+        status: 'SOT'
+      
+    ## Saving the director url
+    - set_fact:
+        director_url : "http://{{ director_ip }}:30380"
+    
+    ## Getting username
+    - name: Get username
+      shell: cat /etc/secret-volume/username
+      register: username
+
+    ## Getting password     
+    - name: Get password
+      shell: cat /etc/secret-volume/password
+      register: password
+
+    ## Get the project id of the project on which the cluster is running
+    - name: Fetch the project id of the project on which the cluster is running
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/project"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        status_code: 200
+      register: project_details
+
+    ## Saving Project id
+    - name: Saving project id
+      set_fact:
+        project_id: "{{ project_details.json.data[0].id }}"
+
+    ## Getting node details of the cluster
+    ## Selecting the node which is in active state in the cluster
+    - name: Getting the node details of the cluster which is in active state
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes?state=active&clusterId={{ cluster_id }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 200
+      register: node_cluster
+
+    ## Define variable node_id
+    - set_fact:
+        node_id: []
+
+    ## Storing the id of the nodes in the cluster
+    - name: Storing the id of nodes in the cluster
+      set_fact:
+        node_id: "{{ node_id  + [item.id] }}"
+      loop: "{{ node_cluster.json.data }}"
+
+    ## Fail the test if the cluster contains less than three nodes
+    - fail:
+        msg: Minimum three nodes are required for the test
+      when: "{{ node_id | length }} < 3"
+
+    ## Labeling node-1 of the Cluster with controlPlaneNode=true and dataPlaneNode=false
+    ## With the first element in the node_id list
+    - name: Labeling node-1 of the cluster
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[0] }}/?action=labelnodes"
+        method: POST
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        status_code: 202
+        body_format: json
+        body: '{"controlPlaneNode": true, "dataPlaneNode": false }'
+      register: labelnode1
+
+    ## Labeling node-2 of the Cluster with controlPlaneNode=false and dataPlaneNode=true
+    ## With the second element in the node_id list
+    - name: Labeling node-2 of the cluster
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[1] }}/?action=labelnodes"
+        method: POST
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 202
+        body: '{"controlPlaneNode": false, "dataPlaneNode": true }'
+      register: labelnode2
+
+
+    ## Labeling node-3 of the Cluster with controlPlaneNode=false and dataPlaneNode=true
+    ## With the third element in the node_id list
+    - name: Labeling node-3 of the cluster
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[2] }}/?action=labelnodes"
+        method: POST
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        body: '{"controlPlaneNode": false, "dataPlaneNode": true }'
+        status_code: 202
+      register: labelnode3
+
+    ## Creating openebs
+    - name: Giving required variables for openebs installation
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/openebses"
+        method: POST
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        body: "{ \"clusterId\": \"{{ cluster_id }}\",\"creatorId\": \"{{ group_id }}\",\"projectId\": \"{{ project_id }}\",\"templateId\": \"{{ template_id }}\",\"namespace\": \"{{ namespace }}\",\"defaultDirectory\": \"{{ default_directory }}\",\"dockerRegistry\": \"{{ docker_registry }}\",\"includeDeviceFilters\": \"{{ include_device_filters }}\",\"excludeDeviceFilters\": \"{{ exclude_device_filters }}\",\"cpuResourceLimit\": \"{{ cpu_resource_limit }}\",\"memoryResourceLimit\": \" {{ memory_resource_limit }}\",\"installationMode\": \"{{ installation_mode }}\" }"            
+        status_code: 201
+      register: get_openebs
+
+    - name: Getting the installation Manifest for openebs installation
+      set_fact:
+        installopenebs: "{{ get_openebs.json.installationManifest }}"
+
+    - name: Getting the id
+      set_fact:
+        openebsid: "{{ get_openebs.json.id }}"
+
+    ## Checking the id
+    - name: Getting into the openebs installtion stage and checking the id
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses/{{ openebsid }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 200
+      register: install_openebs
+
+    # Installing openebs on the external cluster with labeled control plane components
+    - name: Installing openebs on the external cluster with control plane components at node-1 only
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/openebses/{{ openebsid }}/?action=openebsinstall"
+        method: POST
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        body: "{{ installopenebs }}"
+        status_code: 200
+      register: res_openebs
+
+
+    ## Getting openebs job id
+    - name: Getting openebs job id
+      set_fact: 
+        openebs_job_id: "{{ res_openebs.json.id }}"
+
+    ## Getting into the openebsjob
+    - name: Getting into openebs job
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/openebsjobs/{{ openebs_job_id }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 200
+      register: openebs_job  
+
+    ## Getting the openebs jobstatus
+    ## Wait for some time to get the job status
+    - name: Getting the openebs jobStatus
+      set_fact: 
+         jobstatus: "{{ openebs_job.json.jobStatus }}"
+      until: "{{ jobstatus | length }} != 0"
+      delay: 5
+      retries: 10
+
+    ## When we get the job Status as not null
+    ## phase can be Online/Failed
+    - name: Getting jobStatus phase
+      set_fact: 
+        phase: "{{ jobStatus.phase }}"   
+
+    ## Fail when the jobStatus is Failed
+    - fail:
+        msg: "{{ jabstatus.reason }}"
+      when: "{{ phase }} == 'Failed'"
+
+    ## Checking the control plane label on the first node
+    - name: Checking the label on first node of the cluster
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[0] }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 200
+      register: node1
+
+    ## Fail when it gives 'false' to control plane component as we set it 'true' for node-1
+    - fail:
+        msg: The node-1 does not contains the label of control-plane as false
+      when: "{{ node1.labels['mayadata.io/control-plane'] }} != 'true'"
+
+    ## Checking the control plane label on the second node
+    - name: Checking the label on the second node of the cluster
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[1] }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 200
+      register: node2
+
+    ## Fail when it gives 'true' to control plane component as we set it 'false' for node-2
+    - fail:
+        msg: The node does not contains the label of control-plane as true
+      when: "{{ node2.labels['mayadata.io/control-plane'] }} != 'false'"
+
+    ## Checking the control plane label on the third node
+    - name: Checking the label on the third node of the cluster
+      uri:
+        url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[3] }}"
+        method: GET
+        url_username: "{{ username.stdout }}"
+        url_password: "{{ password.stdout }}"
+        force_basic_auth: yes
+        return_content: yes
+        body_format: json
+        status_code: 200
+      register: node3
+
+    ## Fail when it gives 'true' to control plane component as we set it 'false' for node-3
+    - fail:
+        msg: The node does not contains the label of control-plane as true
+      when: "{{ node3.labels['mayadata.io/control-plane'] }} != 'false'"

--- a/litmus/director/openebs-control-plane-test/test_vars.yml
+++ b/litmus/director/openebs-control-plane-test/test_vars.yml
@@ -1,0 +1,14 @@
+test_name: openebs-control-plane-test
+openebs_components: ['openebs-provisioner','openebs-ndm-operator','openebs-ndm','openebs-snapshot-operator','openebs-admission-server','openebs-localpv-provisioner','maya-apiserver']
+group_id: "{{ lookup('env','GROUP_ID') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+template_id: "{{ lookup('env','TEMPLATE_ID') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"
+default_directory: "{{ lookup('env','DEFAULT_DIRECTORY') }}"
+docker_registry: "{{ lookup('env','DOCKER_REGISTRY') }}"
+include_device_filters: "{{ lookup('env','INCLUDE_DEVICE_FILTERS') }}"
+exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
+cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
+memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
+installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

**_Issue it resolve:_** https://github.com/mayadata-io/oep/issues/219

**_This PR is for:_**

 - Adding test case for installing openebs control plane components on specific nodes

**_This issue is for:_**
- Adding test case for installing openebs control plane components on specific nodes

**_Prerequisites:_**

- The cluster should be a minimum of **three** nodes.
- It should have enough `CPU` and `Memory` to install openebs. We can use at least the `n1-standard-1` size of the cluster.

**_Details:_**
 - This issue is for creating the test cases for openebs control plane installation on the specific nodes. It can be done by labeling the nodes before installing the openebs on it. So basically we will test that the labeling feature is working file with respective of control plane components. Control plane components include all the openebs components expect NDM daemonset.

- The tasks involved for creating the test case will be - we will labels nodes as shown in the table.

<table style="width:100%">
  <tr>
    <th>OpenEBS components</th>
    <th>Node-1</th>
    <th>Node-2</th>
    <th>Node-3</th>
  </tr>
  <tr>
    <td><b>Control plane components</b></td>
    <td>True</td>
    <td>Flase</td>
    <td>False</td>
  </tr>
  <tr>
    <td><b>Data plane components</b></td>
    <td>False</td>
    <td>True</td>
    <td>True</td>
  </tr>
</table>

- Now we will test if the `node-1` id labeled with control plane component or not also `node-2` and `node-3` should not be labeled with the control plane components.

**_Logs of the job:_**
- [X] [logs1.txt](https://github.com/mayadata-io/oep/files/4227789/logs1.txt)

