### PR TITLE
[iuoi06]: Install OpenEBS on a machine already OpenEBS is installed with same version using operator.yaml

### DIFF
--- a/litmus/director/openebs-reinstallation/README.md
+++ b/litmus/director/openebs-reinstallation/README.md
@@ -1,0 +1,181 @@
+# openebs-reinstallation-check
+
+<b>tcid:</b> iuoi06<br>
+<b>name:</b> Install OpenEBS on a machine already OpenEBS is installed with same version using operator.yaml<br>
+<b>sidebar_label:</b> openebs-reinstallation-check
+
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Openebs Reinstallation </td>
+    <td> openebs-reinstallation-check</td>
+    <td> GKE </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Along with k8s, Litmus should be installed in the cluster.
+- Every component of the cluster should be healthy and running.
+- Ensure that the `openebs-reinstallation-check` resource is available in the cluster.
+
+## Entry Criteria
+
+- Kubernetes nodes are up and running with no openebs installed in the cluster .
+
+## Exit Criteria
+
+- Kubernetes nodes are up and running with openebs installed twice in the cluster . 
+
+## Details of Test 
+
+- This test focuses on installing openebs from director on a cluster where openebs is already installed. In such situation the openebs is reinstalling on the same cluster which should throw an error that openebs is already installed. 
+
+- **_Labeling the Nodes_**: Nodes are labeled for the control and data components.
+  - `GET` request to the nodes on success -
+  - `POST` request for the change in labels according to the condition - On which node you want to place the data components and on which node you want to place the control plan components.
+- **_Generating the request for openebs installation:_**
+  - A request is generated for openebs installation
+  - `POST` request for openebs installation:
+  - The `GET`  Respond from the previous step (in JSON format) is sent as Request to the for the installation. 
+
+- _**Check for each GET and POST Request and Respond**_
+  - There can be different ways to check the `GET` and `POST` requests - one with the status code verification 
+  - Adding a status test for the previous action 
+  - Adding a task for testing the expected change after each request and response.
+
+## Expected output
+
+- For installing openebs again using Director after insatlling it from `operator.yml` the test should give warning/Error 405 that openebs is already installed.
+
+## Integrations
+
+- This test can be performed on GKE cluster where connected to DOP.
+- The desired specification for installing openebs in a cluster can be done by passing the values from `run_litmus_tes.yml`. And then we have to select the `installation mode` which can have two different modes `basic` and `advance`. For installing openebs with default values use `basic` mode and for installing openebs with the desired value it will be `advance`.
+
+## Steps to Execute the test manually 
+
+- Use `run_litmus_test.yml` with the your `image` (contains the image of the experiment) , `secret`(contains the userid and password), `configmaps`(contains dop url and cluster id) files and other environment variables.
+- Create `run_litmus_test.yml` file in `litmus` namespace. 
+- Check the test log using `kubectl logs -f <jobs-pod-name> -n <litmus>` command.
+
+#### Sample run_litmus_test.yml
+
+```
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: <test-name>-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: <test-name>
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+          
+          ## Take url from configmap config
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Take cluster_id from configmap clusterid
+          - name: CLUSTER_ID    
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          ## Takes group_id from configmap groupid
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          ## It should be 1ot1 Mandatory
+          - name: TEMPLATE_ID
+            value: '1ot1'
+
+          ## Namespace where openebs is installed
+          ## By default in basic mode it is openebs
+          - name: NAMESPACE
+            value: ''
+
+          ## Enter the default directory - It can be /var/openebs
+          - name: DEFAULT_DIRECTORY
+            value: ''
+
+          ##Enter docker registry
+          - name: DOCKER_REGISTRY
+            value: ''
+
+          ## Enter include device filter
+          - name: INCLUDE_DEVICE_FILTERS
+            value: ''
+
+          ## Enter exclude device filter  
+          - name: EXCLUDE_DEVICE_FILTER
+            value: ''
+
+          ## Enter CPU resource limit
+          - name: CPU_RESOURCE_LIMIT
+            value: ''
+
+          ## Enter Memory resource limit
+          - name: MEMORY_RESOURCE_LIMIT
+            value: ''
+          
+          ## It will have values basic/advance
+          ## Note: For basic installation, only template value should be provided
+          ## For adding any additional value - change the installation mode to advance
+          - name: INSTALLATION_MODE
+            value: 'basic'
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: 'default'  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/<test-path>/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        
+```
+
+### Watch Test progress
+
+- View the test progress  
+
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+### Check Test Result
+
+- Check whether the test is Pass or Fail using the following command
+ 
+  `watch -n 1 kubectl logs -f pods -n <namespace>`
+
+- Check the Pass and Fail value at the end of test logs.
+- The pod will be in the `completed` state.

--- a/litmus/director/openebs-reinstallation/README.md
+++ b/litmus/director/openebs-reinstallation/README.md
@@ -32,7 +32,7 @@
 
 ## Exit Criteria
 
-- Kubernetes nodes are up and running with openebs installed twice in the cluster . 
+- Kubernetes nodes are up and running with an error message 405 that openebs is already installed. 
 
 ## Details of Test 
 

--- a/litmus/director/openebs-reinstallation/run_litmus_test.yml
+++ b/litmus/director/openebs-reinstallation/run_litmus_test.yml
@@ -48,6 +48,10 @@ spec:
                 name: groupid
                 key: group_id
 
+          ## Enter OpenEBS Version for installing it from operator.yml
+          - name: OPENEBS_VERSION
+            value: '1.7.0'                
+
           ## It should be 1ot1 Mandatory
           - name: TEMPLATE_ID
             value: '1ot1'

--- a/litmus/director/openebs-reinstallation/run_litmus_test.yml
+++ b/litmus/director/openebs-reinstallation/run_litmus_test.yml
@@ -1,0 +1,95 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openebs-reinstallation-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: openebs-reinstallation-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+          
+          ## Take url from configmap config
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Take cluster_id from configmap clusterid
+          - name: CLUSTER_ID    
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          ## Takes group_id from configmap groupid
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          ## It should be 1ot1 Mandatory
+          - name: TEMPLATE_ID
+            value: '1ot1'
+
+          ## Namespace where openebs is installed
+          ## By default in basic mode it is openebs
+          - name: NAMESPACE
+            value: ''
+
+          ## Enter the default directory - It can be /var/openebs
+          - name: DEFAULT_DIRECTORY
+            value: ''
+
+          ##Enter docker registry
+          - name: DOCKER_REGISTRY
+            value: ''
+
+          ## Enter include device filter
+          - name: INCLUDE_DEVICE_FILTERS
+            value: ''
+
+          ## Enter exclude device filter  
+          - name: EXCLUDE_DEVICE_FILTER
+            value: ''
+
+          ## Enter CPU resource limit
+          - name: CPU_RESOURCE_LIMIT
+            value: ''
+
+          ## Enter Memory resource limit
+          - name: MEMORY_RESOURCE_LIMIT
+            value: ''
+          
+          ## It will have values basic/advance
+          ## Note: For basic installation only template value slould be provided
+          ## For adding any additional value - change the installation mode to advance
+          - name: INSTALLATION_MODE
+            value: 'basic'
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: 'default'  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/openebs-self-install/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        

--- a/litmus/director/openebs-reinstallation/test.yml
+++ b/litmus/director/openebs-reinstallation/test.yml
@@ -147,3 +147,4 @@
         - include_tasks: /ansible-utils/update_litmus_result_resource.yml
           vars:
             status: 'EOT'
+            

--- a/litmus/director/openebs-reinstallation/test.yml
+++ b/litmus/director/openebs-reinstallation/test.yml
@@ -1,0 +1,143 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block: 
+      
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## Record Start-Of-Test In Litmus Result CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        ## Saving the director url
+        - set_fact:
+            director_url : "http://{{ director_ip }}:30380"
+        
+        ## Getting username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting password     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        ## Fetch the projectid of the project where the cluster is running
+        - name: Fetch the projectid of the project where the cluster is running
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/project"
+            method: GET
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            status_code: 200
+          register: project_details
+
+        ## Saving Project id
+        - name: Saving project id
+          set_fact:
+            project_id: "{{ project_details.json.data[0].id }}"
+
+        ## Installing openebs on the cluster
+        - name: Installing openebs on the cluster
+          shell: kubectl apply -f https://openebs.github.io/charts/openebs-operator-{{ openebs_version }}.yaml 
+
+        ## Getting node details of the cluster
+        ## Selecting the node which is in active state in the cluster
+        - name: Getting the node details of the cluster which is in active state
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes?state=active&clusterId={{ cluster_id }}"
+            method: GET
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 200
+          register: node_cluster
+
+        ## Define variable node_id
+        - set_fact:
+            node_id: []
+
+        ## Storing the id of the nodes in the cluster
+        - name: Storing the id of nodes in the cluster
+          set_fact:
+            node_id: "{{ node_id  + [item.id] }}"
+          loop: "{{ node_cluster.json.data }}"
+
+        ## Fail the test if it contains less than two nodes
+        ## Minimum two nodes required
+        - name: Checking if the cluster contains atleast two nodes
+          fail:
+            msg: Minimum two nodes are required for the test
+          when: "{{ node_id | length }} < 2"
+
+        ## Labeling node-1 of the Cluster with controlPlaneNode=true and dataPlaneNode=flase
+        ## With the first element in the node_id list
+        - name: Labeling node-1 of the cluster
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[0] }}/?action=labelnodes"
+            method: POST
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            status_code: 202
+            body_format: json
+            body: '{"controlPlaneNode": true, "dataPlaneNode": flase }'
+          register: labelnode1
+
+        ## Labeling node-2 of the Cluster with controlPlaneNode=false and dataPlaneNode=true
+        ## With the second element in the node_id list
+        - name: Labeling node-2 of the cluster
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/nodes/{{ node_id[1] }}/?action=labelnodes"
+            method: POST
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            status_code: 202
+            body: '{"controlPlaneNode": false, "dataPlaneNode": true }'
+          register: labelnode2
+
+        ## Installing openebs
+        ## Also accepted error code is 405 which means openebs is already installed
+        - name: Giving required variables for openebs installation
+          uri:
+            url: "{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/openebses"
+            method: POST
+            url_username: "{{ username.stdout }}"
+            url_password: "{{ password.stdout }}"
+            force_basic_auth: yes
+            return_content: yes
+            body_format: json
+            body: '{ "clusterId": "{{ cluster_id }}","creatorId": "{{ group_id }}","projectId": "{{ project_id }}","templateId": "{{ template_id }}","namespace": "{{ namespace }}","defaultDirectory": "{{ default_directory }}","dockerRegistry": "{{ docker_registry }}","includeDeviceFilters": "{{ include_device_filters }}","excludeDeviceFilters": "{{ exclude_device_filters }}","cpuResourceLimit": "{{ cpu_resource_limit }}","memoryResourceLimit": " {{ memory_resource_limit }}","installationMode": "{{ installation_mode }}" }'         
+            status_code: 405
+          register: get_openebs
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/litmus/director/openebs-reinstallation/test_vars.yml
+++ b/litmus/director/openebs-reinstallation/test_vars.yml
@@ -12,4 +12,4 @@ exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
 cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
 memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
 installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"
-openebs_version: 1.7.0
+openebs_version: "{{ lookup('env','OPENEBS_VERSION') }}"

--- a/litmus/director/openebs-reinstallation/test_vars.yml
+++ b/litmus/director/openebs-reinstallation/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: openebs-reinstallation
+openebs_components: ['openebs-provisioner','openebs-ndm-operator','openebs-ndm','openebs-snapshot-operator','openebs-admission-server','openebs-localpv-provisioner','maya-apiserver']
+group_id: "{{ lookup('env','GROUP_ID') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+template_id: "{{ lookup('env','TEMPLATE_ID') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"
+default_directory: "{{ lookup('env','DEFAULT_DIRECTORY') }}"
+docker_registry: "{{ lookup('env','DOCKER_REGISTRY') }}"
+include_device_filters: "{{ lookup('env','INCLUDE_DEVICE_FILTERS') }}"
+exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
+cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
+memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
+installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"
+openebs_version: 1.7.0


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

**_This PR is for:_**

- Install OpenEBS on a machine already OpenEBS is installed with same version using operator.yaml

**_Details:_**

- This issue is for writing the test cases for getting an appropriate warning when a user tries to install openebs in a cluster where it is already installed. As openebs do not support this feature so when a user tries to install he/she will receive an error with status code `405` which will be telling Openebs is already installed. We should not fail the task like this we will be giving warning to the user that the openebs in already installed if the user wants to install it again then he should delete/remove the previously installed openebs and try again. 