### PR TITLE
(big-fix): Adding openebs cleanup task in the tests and cleaning up node labels of the cluster

### DIFF
--- a/litmus/director/openebs-control-plane-test/test.yml
+++ b/litmus/director/openebs-control-plane-test/test.yml
@@ -232,11 +232,8 @@
         ## Removing the labels from the cluster nodes
         - include_tasks: ../../../utils/openebs-label-cleanup.yaml
 
-        ## Deleting openebs 
-        - name: Deleting openebs
-          shell: kubectl delete ns {{ namespace }}
-          args:
-            executable: /bin/bash
+        ## Deleting openebs from the cluster
+        - include_tasks: ../../../utils/openebs-cleanup.yml
 
         - set_fact:
             flag: "Pass"

--- a/litmus/director/openebs-control-plane-test/test.yml
+++ b/litmus/director/openebs-control-plane-test/test.yml
@@ -178,9 +178,14 @@
             body_format: json
             status_code: 200
           register: openebs_job
-          until: openebs_job.json.jobStatus.phase is defined and openebs_job.json.jobStatus.phase == "Online"
+          until: openebs_job.json.jobStatus != ""
           delay: 5
           retries: 20
+
+        ## Checking wether the openebs_job pod is in online state or not.
+        - name: Checking phase of openebs_job 
+          shell: echo "{{ openebs_job.json.jobStatus.phase }}"
+          failed_when: "'{{ openebs_job.json.jobStatus.phase }}' != 'Online'"
 
         ## Checking the control plane label on the first node
         - name: Checking the label on first node of the cluster
@@ -223,6 +228,15 @@
             status_code: 200
           register: node3
           failed_when: "node3.json.labels['mayadata.io/control-plane'] != 'true'"
+
+        ## Removing the labels from the cluster nodes
+        - include_tasks: ../../../utils/openebs-label-cleanup.yaml
+
+        ## Deleting openebs 
+        - name: Deleting openebs
+          shell: kubectl delete ns {{ namespace }}
+          args:
+            executable: /bin/bash
 
         - set_fact:
             flag: "Pass"

--- a/litmus/director/openebs-control-plane-test/test_vars.yml
+++ b/litmus/director/openebs-control-plane-test/test_vars.yml
@@ -12,3 +12,4 @@ exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
 cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
 memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
 installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"
+app_ns: app-mongo-ns

--- a/litmus/director/openebs-data-plane-test/test.yml
+++ b/litmus/director/openebs-data-plane-test/test.yml
@@ -232,11 +232,8 @@
         ## Removing the labels from the cluster nodes
         - include_tasks: ../../../utils/openebs-label-cleanup.yaml
 
-        ## Deleting openebs 
-        - name: Deleting openebs
-          shell: kubectl delete ns {{ namespace }}
-          args:
-            executable: /bin/bash
+        ## Deleting openebs from the cluster
+        - include_tasks: ../../../utils/openebs-cleanup.yml
             
         - set_fact:
             flag: "Pass"

--- a/litmus/director/openebs-data-plane-test/test.yml
+++ b/litmus/director/openebs-data-plane-test/test.yml
@@ -178,9 +178,14 @@
             body_format: json
             status_code: 200
           register: openebs_job
-          until: openebs_job.json.jobStatus.phase is defined and openebs_job.json.jobStatus.phase == "Online"
+          until: openebs_job.json.jobStatus != ""
           delay: 5
           retries: 20
+
+        ## Checking wether the openebs_job pod is in online state or not.
+        - name: Checking phase of openebs_job 
+          shell: echo "{{ openebs_job.json.jobStatus.phase }}"
+          failed_when: "'{{ openebs_job.json.jobStatus.phase }}' != 'Online'"
 
         ## Checking the data plane label on the first node
         - name: Checking the label on first node of the cluster
@@ -224,6 +229,15 @@
           register: node3
           failed_when: "node3.json.labels['mayadata.io/data-plane'] != 'true'"
 
+        ## Removing the labels from the cluster nodes
+        - include_tasks: ../../../utils/openebs-label-cleanup.yaml
+
+        ## Deleting openebs 
+        - name: Deleting openebs
+          shell: kubectl delete ns {{ namespace }}
+          args:
+            executable: /bin/bash
+            
         - set_fact:
             flag: "Pass"
 

--- a/litmus/director/openebs-data-plane-test/test_vars.yml
+++ b/litmus/director/openebs-data-plane-test/test_vars.yml
@@ -12,3 +12,4 @@ exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
 cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
 memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
 installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"
+app_ns: app-mongo-ns

--- a/litmus/director/openebs-install/test.yml
+++ b/litmus/director/openebs-install/test.yml
@@ -194,11 +194,8 @@
         ## Removing the labels from the cluster nodes
         - include_tasks: ../../../utils/openebs-label-cleanup.yaml
 
-        ## Deleting openebs 
-        - name: Deleting openebs
-          shell: kubectl delete ns {{ namespace }}
-          args:
-            executable: /bin/bash
+        ## Deleting openebs from the cluster
+        - include_tasks: ../../../utils/openebs-cleanup.yml
     
         ## Setting flag as Pass
         - set_fact:

--- a/litmus/director/openebs-install/test.yml
+++ b/litmus/director/openebs-install/test.yml
@@ -27,9 +27,31 @@
     - name: Get password
       shell: cat /etc/secret-volume/password
       register: password
-    ## Fetch Project deatils
 
     - block:
+
+        ## Checking if openebs is already installed in the cluster
+        - name: Check if openebs is already installed
+          shell: kubectl get deploy --all-namespaces | grep maya-apiserver | awk '{print $1}' | wc -l
+          args:
+            executable: /bin/bash
+          register: count_maya_api
+
+        ## If openebs is installed in the cluster then get the namespace
+        - name: Getting the namespace where openebs is installed 
+          shell: kubectl get deploy --all-namespaces | grep maya-apiserver | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: openebs_namespace
+          when: "count_maya_api.stdout == '1'"
+
+        ## Delete openebs 
+        - name: Deleting openebs
+          shell: kubectl delete namespace {{ openebs_namespace.stdout }}
+          args:
+            executable: /bin/bash
+          when: "count_maya_api.stdout == '1'"
+          
         ## Fetch Project deatils
         - name: Fetch the project details
           uri:
@@ -168,6 +190,15 @@
         - name: Checking phase of openebs_job 
           shell: echo "{{ openebs_job.json.jobStatus.phase }}"
           failed_when: "'{{ openebs_job.json.jobStatus.phase }}' != 'Online'"
+
+        ## Removing the labels from the cluster nodes
+        - include_tasks: ../../../utils/openebs-label-cleanup.yaml
+
+        ## Deleting openebs 
+        - name: Deleting openebs
+          shell: kubectl delete ns {{ namespace }}
+          args:
+            executable: /bin/bash
     
         ## Setting flag as Pass
         - set_fact:

--- a/litmus/director/openebs-install/test_vars.yml
+++ b/litmus/director/openebs-install/test_vars.yml
@@ -11,3 +11,4 @@ exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
 cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
 memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
 installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"
+app_ns: app-mongo-ns

--- a/litmus/director/openebs-self-install/test.yml
+++ b/litmus/director/openebs-self-install/test.yml
@@ -31,13 +31,27 @@
           shell: cat /etc/secret-volume/password
           register: password
 
-        ## Checking if openebs is already installed
+        ## Checking if openebs is already installed in the cluster
         - name: Check if openebs is already installed
-          shell: kubectl get deploy maya-apiserver --all-namespaces | wc -l
+          shell: kubectl get deploy --all-namespaces | grep maya-apiserver | awk '{print $1}' | wc -l
           args:
             executable: /bin/bash
-          register: maya_api
-          failed_when: "{{ maya_api.stdout }} != 0"
+          register: count_maya_api
+
+        ## If openebs is installed in the cluster then get the namespace
+        - name: Getting the namespace where openebs is installed 
+          shell: kubectl get deploy --all-namespaces | grep maya-apiserver | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: openebs_namespace
+          when: "count_maya_api.stdout == '1'"
+
+        ## Delete openebs 
+        - name: Deleting openebs
+          shell: kubectl delete namespace {{ openebs_namespace.stdout }}
+          args:
+            executable: /bin/bash
+          when: "count_maya_api.stdout == '1'"
 
         ## Fetch the projectid of the project where the cluster is running
         - name: Fetch the project details of the project where the cluster is running
@@ -195,8 +209,16 @@
           register: containerStatus
           until: "containerStatus.stdout == 'true'"
           retries: 20
-          delay: 2          
+          delay: 2         
 
+        ## Removing the labels from the cluster nodes
+        - include_tasks: ../../../utils/openebs-label-cleanup.yaml
+
+        ## Deleting openebs 
+        - name: Deleting openebs
+          shell: kubectl delete ns {{ namespace }}
+          args:
+            executable: /bin/bash
 
         - set_fact:
             flag: "Pass"

--- a/litmus/director/openebs-self-install/test.yml
+++ b/litmus/director/openebs-self-install/test.yml
@@ -214,11 +214,8 @@
         ## Removing the labels from the cluster nodes
         - include_tasks: ../../../utils/openebs-label-cleanup.yaml
 
-        ## Deleting openebs 
-        - name: Deleting openebs
-          shell: kubectl delete ns {{ namespace }}
-          args:
-            executable: /bin/bash
+        ## Deleting openebs from the cluster
+        - include_tasks: ../../../utils/openebs-cleanup.yml
 
         - set_fact:
             flag: "Pass"

--- a/litmus/director/openebs-self-install/test_vars.yml
+++ b/litmus/director/openebs-self-install/test_vars.yml
@@ -13,3 +13,4 @@ exclude_device_filters: "{{ lookup('env','EXCLUDE_DEVICE_FILTER') }}"
 cpu_resource_limit: "{{ lookup('env','CPU_RESOURCE_LIMIT') }}"
 memory_resource_limit: "{{ lookup('env','MEMORY_RESOURCE_LIMIT') }}"
 installation_mode: "{{ lookup('env','INSTALLATION_MODE') }}"
+app_ns: app-mongo-ns

--- a/utils/openebs-cleanup.yml
+++ b/utils/openebs-cleanup.yml
@@ -20,12 +20,6 @@
       args:
         executable: /bin/bash
 
-    ## Cleaning CRDs
-    - name: Removing CRDs
-      shell: kubectl delete crds --all
-      args:
-        executable: /bin/bash
-
     ## Cleaning up Blockdevices
     - name: Removing Blockdevices
       shell: kubectl delete bd -n {{ namespace }} --all

--- a/utils/openebs-cleanup.yml
+++ b/utils/openebs-cleanup.yml
@@ -1,0 +1,45 @@
+- hosts: localhost
+  
+  tasks:
+        
+    ## Removing Application
+    - name: Deleting application namespace
+      shell: kubectl delete ns app-mongo-ns
+      args:
+        executable: /bin/bash  
+
+    ## Cleaning SPC from the cluster
+    - name: Removing SPC from the cluster
+      shell: kubectl delete spc --all
+      args:
+        executable: /bin/bash
+          
+    ## Cleaning PV form the cluster
+    - name: Removing PV from the cluster
+      shell: kubectl delete pv -n {{ namespace }} --all
+      args:
+        executable: /bin/bash
+
+    ## Cleaning up Blockdevices
+    - name: Removing Blockdevices
+      shell: kubectl delete bd -n {{ namespace }} --all
+      args:
+        executable: /bin/bash
+          
+    ## Cleaning up deployment
+    - name: Removing deployment from openebs namespace
+      shell: kubectl delete deploy -n {{ namespace }} --all
+      args:
+        executable: /bin/bash
+
+    ## Cleaning up NDM Daemonset
+    - name: Removing NDM DaemonSet
+      shell: kubectl delete ds -n {{ namespace }} --all
+      args:
+        executable: /bin/bash
+  
+    ## Cleaning up OpenEBS Namespace
+    - name: Removing openebs namespace
+      shell: kubectl delete ns {{ namespace }}
+      args:
+        executable: /bin/bash        

--- a/utils/openebs-cleanup.yml
+++ b/utils/openebs-cleanup.yml
@@ -20,6 +20,12 @@
       args:
         executable: /bin/bash
 
+    ## Cleaning CRDs
+    - name: Removing CRDs
+      shell: kubectl delete crds --all
+      args:
+        executable: /bin/bash
+
     ## Cleaning up Blockdevices
     - name: Removing Blockdevices
       shell: kubectl delete bd -n {{ namespace }} --all

--- a/utils/openebs-cleanup.yml
+++ b/utils/openebs-cleanup.yml
@@ -4,7 +4,7 @@
         
     ## Removing Application
     - name: Deleting application namespace
-      shell: kubectl delete ns app-mongo-ns
+      shell: kubectl delete ns {{ app_ns }}
       args:
         executable: /bin/bash  
 

--- a/utils/openebs-label-cleanup.yaml
+++ b/utils/openebs-label-cleanup.yaml
@@ -1,0 +1,46 @@
+- hosts: localhost
+  
+  tasks:
+        
+    ## Removing control plane label from node-1
+    - name: Removing control plane label from the node
+      shell: kubectl label nodes {{ node_id[0] }} mayadata.io/control-plane-
+      args:
+        executable: /bin/bash
+      when: "{{ node_id[0] }} is defined and {{ node_id[0] }} != ''"
+        
+    ## Removing control plane label from node-2
+    - name: Removing control plane label from the node
+      shell: kubectl label nodes {{ node_id[1] }} mayadata.io/control-plane-
+      args:
+        executable: /bin/bash
+      when: "{{ node_id[1] }} is defined and {{ node_id[1] }} != ''"
+
+    ## Removing control plane label from node-3
+    - name: Removing control plane label from the node
+      shell: kubectl label nodes {{ node_id[2] }} mayadata.io/control-plane-
+      args:
+        executable: /bin/bash
+      when: "{{ node_id[2] }} is defined and {{ node_id[2] }} != ''"
+
+    ## Removing data plane label from node-1
+    - name: Removing control plane label from the node
+      shell: kubectl label nodes {{ node_id[0] }} mayadata.io/data-plane-
+      args:
+        executable: /bin/bash
+      when: "{{ node_id[0] }} is defined and {{ node_id[0] }} != ''"
+     
+    ## Removing data plane label from node-2
+    - name: Removing control plane label from the node
+      shell: kubectl label nodes {{ node_id[1] }} mayadata.io/data-plane-
+      args:
+        executable: /bin/bash
+      when: "{{ node_id[1] }} is defined and {{ node_id[1] }} != ''"
+
+    ## Removing data plane label from node-3
+    - name: Removing control plane label from the node
+      shell: kubectl label nodes {{ node_id[2] }} mayadata.io/data-plane-
+      args:
+        executable: /bin/bash
+      when: "{{ node_id[2] }} is defined and {{ node_id[2] }} != ''"
+      


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

**_This PR is for:_**
- Adding openebs cleanup task in the tests and cleaning up node labels of the cluster
 
**_Details:_**

- This cleanup task will try to reset the changes that occurred due to different actions in our test. It is important and mandatory to reset the changes after each and every test so that the upcoming test gets a clean environment and does not get affected due to any of the previous tests.