### PR TITLE
[iuod28]Upgrade the application with 3 replicas when one replica pod is not running

### DIFF
--- a/litmus/director/upgrade-replica-pod-pending/run_litmus_test.yml
+++ b/litmus/director/upgrade-replica-pod-pending/run_litmus_test.yml
@@ -1,0 +1,64 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: upgrade-replica-pod-pending-check-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: upgrade-replica-pod-pending-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: director-user-pass
+      containers:
+      - name: ansibletest
+        image: mayadataio/dop-validator:ci 
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secret-volume
+          readOnly: true
+          mountPath: "/etc/secret-volume"
+        env:
+
+          ## Takes director-ip from configmap director-ip
+          - name: DIRECTOR_IP
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: url
+
+          ## Takes group-id from configmap group-id
+          - name: GROUP_ID
+            valueFrom:
+              configMapKeyRef:
+                name: groupid
+                key: group_id
+
+          - name: NAMESPACE
+            value: ''
+     
+          - name: OPENEBS_TARGET_VERSION
+            value: 1.7.0
+
+          ## Takes cluster_id from configmap
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: clusterid
+                key: cluster_id
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./litmus/director/upgrade-replica-pod-pending/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      imagePullSecrets:
+      - name: oep-secret   

--- a/litmus/director/upgrade-replica-pod-pending/test.yml
+++ b/litmus/director/upgrade-replica-pod-pending/test.yml
@@ -143,6 +143,11 @@
                 id: '{{ maya_app.json.data[0].id }}'
             status_code: 405
           register: upgrade_claim
+
+        ## Removed taint from node1
+        - name: Remove the taint from node1
+          shell: >
+            kubectl taint nodes {{ node_name.stdout }} l-
         
         ## Setting flag as pass
         - set_fact:

--- a/litmus/director/upgrade-replica-pod-pending/test.yml
+++ b/litmus/director/upgrade-replica-pod-pending/test.yml
@@ -100,7 +100,7 @@
         ##  Get the node_name of corresponding job
         - name: Get the node_name of corresponding job
           shell: >
-            kubectl get pod {{replica_pod_name.stdout}} -n {{ pod_namespace.stdout }} -o jsonpath={.spec.nodeName}
+            kubectl get pod {{ pod_name.stdout }} -n {{ pod_namespace.stdout }} -o jsonpath={.spec.nodeName}
           register: node_name
         
         ## Taint the node in which the pod is scheduled

--- a/litmus/director/upgrade-replica-pod-pending/test.yml
+++ b/litmus/director/upgrade-replica-pod-pending/test.yml
@@ -1,0 +1,162 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+  
+        ## Generating the testname for deployment
+        - include_tasks: /ansible-utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        - set_fact:
+            director_url : "http://{{ director_ip }}:30380"
+
+        ## Getting the username
+        - name: Get username
+          shell: cat /etc/secret-volume/username
+          register: username
+
+        ## Getting the password.stdout     
+        - name: Get password
+          shell: cat /etc/secret-volume/password
+          register: password
+
+        ## Check whether openebs components are in Running state or not
+        - name: Fetch OpenEBS control plane pods state
+          shell: kubectl get pods -n {{ namespace }}  | grep {{ item }} | awk '{print $3}' | awk -F':' '{print $1}' | tail -n 1
+          register: app_status
+          until: app_status.stdout == 'Running'
+          with_items:
+            - "{{ openebs_components }}"
+          retries: 20
+          delay: 5
+
+        ## Get application volume health status for replica-1
+        - name: Get application volume health status for replica-1
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayaapplications'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: volume_health
+          until: "volume_health.json.data[0].data.pods[0].volumes[0].replica[0].state=='Healthy'"
+          retries: 20
+          delay: 2
+        
+        ## Get application volume health status for replica-2
+        - name: Get application volume health status for replica-2
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayaapplications'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: volume_health
+          until: "volume_health.json.data[0].data.pods[0].volumes[0].replica[1].state=='Healthy'"
+          retries: 20
+          delay: 2
+
+        ## Get application volume health status for replica-3
+        - name: Get application volume health status for replica-3
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayaapplications'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: volume_health
+          until: "volume_health.json.data[0].data.pods[0].volumes[0].replica[2].state=='Healthy'"
+          retries: 20
+          delay: 2
+        
+        ## Get replicas of application volumes
+        - name: Get replicas of application volumes
+          shell: >
+            kubectl get pods --all-namespaces -l {{ pod_label }} -o jsonpath='{.items[0].metadata.name}'
+          register: pod_name
+
+        ## Fetch namespace of replica pod
+        - name: Fetch namespace of replica pod
+          shell: >
+            kubectl get pods --all-namespaces -l {{ pod_label }} -o jsonpath='{.items[0].metadata.namespace}'
+          register: pod_namespace
+        
+        ##  Get the node_name of corresponding job
+        - name: Get the node_name of corresponding job
+          shell: >
+            kubectl get pod {{replica_pod_name.stdout}} -n {{ pod_namespace.stdout }} -o jsonpath={.spec.nodeName}
+          register: node_name
+        
+        ## Taint the node in which the pod is scheduled
+        - name: Taint the node in which pod is scheduled
+          shell: >
+            kubectl taint nodes {{ node_name.stdout }} l=b:NoSchedule
+        
+        ## Delete the replica pod of volume
+        - name: Delete the replica pod of volume
+          shell: > 
+            kubectl delete pod {{ pod_name.stdout }} -n {{ pod_namespace.stdout }}
+
+        ## Get application details
+        - name: Get application details
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/clusters/{{ cluster_id }}/mayaapplications'
+            method: GET
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+          register: maya_app
+        
+        ## Upgrade application volume
+        - name: Upgrade application volume
+          uri:
+            url: '{{ director_url }}/v3/groups/{{ group_id }}/openebsupgradeclaims'
+            method: POST
+            url_username: '{{ username.stdout }}'
+            url_password: '{{ password.stdout }}'
+            return_content: yes
+            force_basic_auth: yes
+            body_format: json
+            body:
+              clusterId: '{{ cluster_id }}'
+              kind: applicationUpgrade
+              targetVersion: '{{ openebs_target_version }}'
+              upgradeComponents:
+                id: '{{ maya_app.json.data[0].id }}'
+            status_code: 405
+          register: upgrade_claim
+        
+        ## Setting flag as pass
+        - set_fact:
+              flag: 'Pass'
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: 'Fail'
+    
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /ansible-utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+
+        

--- a/litmus/director/upgrade-replica-pod-pending/test_vars.yml
+++ b/litmus/director/upgrade-replica-pod-pending/test_vars.yml
@@ -1,0 +1,17 @@
+test_name: upgrade-replica-pod-pending-check
+openebs_target_version: "{{ lookup('env','OPENEBS_TARGET_VERSION') }}"
+openebs_components:
+  [
+    'openebs-provisioner',
+    'openebs-ndm-operator',
+    'openebs-ndm',
+    'openebs-snapshot-operator',
+    'openebs-admission-server',
+    'openebs-localpv-provisioner',
+    'maya-apiserver',
+  ]
+namespace: "{{ lookup('env','NAMESPACE') }}"
+group_id: "{{ lookup('env','GROUP_ID') }}"
+cluster_id: "{{ lookup('env','CLUSTER_ID') }}"
+director_ip: "{{ lookup('env','DIRECTOR_IP') }}"
+pod_label: "openebs.io/replica=jiva-replica"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Upgrade control plane components when one replica pod is not running.

**_Details:_**

**_Steps involved in openebs update in cluster:_**

- **Installing openebes**: 
  - Check whether all the openebs components are in running state or not.
  - Check whether application volumes are in running state or not.

- **Steps involved in the test case**
  -  To send one application volume replica to pending state just taint the node with `l=b:NoSchedule`
  -  Now delete the particular pod which was present in that node.
  - Now replica pod will go into `pending` state.
  - After pod went to pending state try to upgrade control plane components.
  - It should give error code `405` and the test case will pass when it gives response status code `405`

**Folder Added:** 
-/oep/litmus/director/upgrade-replica-pod-pending
Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>
[replica-upgradetest.txt](https://github.com/mayadata-io/oep/files/4296731/replica-upgradetest.txt)
